### PR TITLE
chore: use PROJECT_SOURCE instead of PROJECTS_ROOT

### DIFF
--- a/devfile.yaml
+++ b/devfile.yaml
@@ -2,9 +2,9 @@ schemaVersion: 2.1.0
 metadata:
   name: nodejs-angular
 components:
-  - name: nodejs
+  - name: tools
     container:
-      image: quay.io/devfile/universal-developer-image:ubi8-latest
+      image: quay.io/devfile/universal-developer-image:ubi8-0e189d9
       endpoints:
         - exposure: public
           name: angular
@@ -12,28 +12,31 @@ components:
           targetPort: 4200
       memoryLimit: 2G
       mountSources: true
+
 commands:
-  - id: install
+  - id: install-dependencies
     exec:
       label: "Install all required dependencies"
-      component: nodejs
-      workingDir: ${PROJECTS_ROOT}/nodejs-angular
+      component: tools
+      workingDir: ${PROJECT_SOURCE}
       commandLine: "yarn install"
       group:
         kind: build
+
   - id: build
     exec:
       label: "Build application"
-      component: nodejs
-      workingDir: ${PROJECTS_ROOT}/nodejs-angular
+      component: tools
+      workingDir: ${PROJECT_SOURCE}
       commandLine: "yarn build"
       group:
         kind: build
+
   - id: start
     exec:
       label: "Start application"
-      component: nodejs
-      workingDir: ${PROJECTS_ROOT}/nodejs-angular
+      component: tools
+      workingDir: ${PROJECT_SOURCE}
       commandLine: "yarn run start --host 0.0.0.0 --disableHostCheck true"
       group:
         kind: run


### PR DESCRIPTION
Signed-off-by: Vitaliy Gulyy <vgulyy@redhat.com>

- Replaces PROJECTS_ROOT environment variable on PROJECT_SOURCE in devfile commands
- Bumps to the latest tag of universal developer image
