### PR TITLE
chore: remove 'vscode.typescript-language-features' extension from recommendations

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -2,7 +2,6 @@
     // See https://go.microsoft.com/fwlink/?LinkId=827846
     // for the documentation about the extensions.json format
     "recommendations": [
-      "vscode.typescript-language-features",
       "ms-vscode.js-debug"
     ]
 }


### PR DESCRIPTION
Signed-off-by: Vitaliy Gulyy <vgulyy@redhat.com>

There is no need to keep **vscode.typescript-language-features** in recommendations as it is already included into Che-Code as built-in.

Solves https://github.com/eclipse/che/issues/21937