### PR TITLE
Set devfile schemaVersion: 2.2.2

### DIFF
--- a/devfile.yaml
+++ b/devfile.yaml
@@ -1,4 +1,4 @@
-schemaVersion: 2.1.0
+schemaVersion: 2.2.2
 metadata:
   name: nodejs-angular
 components:


### PR DESCRIPTION
Set devfile schemaVersion: 2.2.2


![screenshot-che-dogfooding apps che-dev x6e0 p1 openshiftapps com-2024 01 31-16_00_20](https://github.com/che-samples/nodejs-angular/assets/1271546/66ade6db-27b3-4bf0-add1-78aa4007b712)

Related issue: https://github.com/eclipse/che/issues/21985

